### PR TITLE
some fix to .gitignore to ignore files created when running setup.py, and fix pydv.py so it works out-of-box when installed with setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 *.orig
 .idea
 *.pdf
+*.egg-info
 .DS_Store
 mypdv
 dist
 pydv/docs/_build
+build

--- a/pydv/pydvpy.py
+++ b/pydv/pydvpy.py
@@ -93,7 +93,7 @@ try:
 except:
     stylesLoaded = False
 
-import curve
+from . import curve
 
 try:
     import pact.pdb as pdb


### PR DESCRIPTION
Hello Kevin,

I have created a PR to fix some issues.

* Added some files and directories to ``.gitignore`` that ``setuptools`` creates.
* In ``pydv.py`` changed import to ``from . import curve`` so that PyDV installed with ``setuptools`` now works out of the box.

Further suggestion, in ``README.md`` perhaps change the help to say ``from pydv import pydvpy as pydvif``?