### PR TITLE
fix: import pydv.curve as curve

### DIFF
--- a/pydv/pydvpy.py
+++ b/pydv/pydvpy.py
@@ -94,7 +94,7 @@ try:
 except:
     stylesLoaded = False
 
-import curve
+import pydv.curve as curve
 
 try:
     import pact.pdb as pdb


### PR DESCRIPTION
Problem: importing curve does not work in all scenarios

Fix: we can instead import relative to the module, pydv.curve as curve.

### Description

Resolves #275 and #257 

### Checklist:

<!-- Remove any that are not applicable -->

- [ ] I have added/updated an image test.
- [ ] I have run the image tests on RZ and they pass.
- [ ] I have run the WSC tests on RZ and they pass.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have build the docs on sphinx and they look correct.
- [ ] I have updated the release notes.
- [ ] I have run `pydv/scripts/update_version_and_date.py <major, minor, patch>`.
